### PR TITLE
fix: avoid negative file start pointer

### DIFF
--- a/.changeset/selfish-buckets-complain.md
+++ b/.changeset/selfish-buckets-complain.md
@@ -1,0 +1,5 @@
+---
+'@cypherock/cysync-desktop': patch
+---
+
+Fixed Negative start value of file pointer

--- a/apps/desktop/src/main/utils/logs.ts
+++ b/apps/desktop/src/main/utils/logs.ts
@@ -4,7 +4,7 @@ import { logFilePath } from '.';
 export const getCySyncLogs = async (): Promise<string[]> => {
   const fileSize = (await fs.promises.stat(logFilePath)).size;
   const readStream = fs.createReadStream(logFilePath, {
-    start: fileSize - 1024 * 1024,
+    start: Math.max(0, fileSize - 1024 * 1024),
     end: fileSize,
   });
   const logLines = [];


### PR DESCRIPTION
Fix Following Error:

![image](https://github.com/Cypherock/cypherock-cysync/assets/44930179/41c41fbe-7860-43f3-935e-76c5da8481f8)
