### PR TITLE
fix: show parent icon as sub-icon for clarity

### DIFF
--- a/packages/cysync-core/src/dialogs/Receive/Dialogs/Components/AddressDisplay.tsx
+++ b/packages/cysync-core/src/dialogs/Receive/Dialogs/Components/AddressDisplay.tsx
@@ -40,6 +40,9 @@ export const AddressDisplay: React.FC = () => {
           <CoinIcon
             parentAssetId={selectedAccount?.parentAssetId ?? ''}
             assetId={selectedAccount?.assetId ?? ''}
+            withParentIconAtBottom
+            subContainerSize="17px"
+            subIconSize="16px"
             size={32}
           />
           <Typography variant="h5">

--- a/packages/cysync-core/src/pages/MainApp/Portfolio/Content.tsx
+++ b/packages/cysync-core/src/pages/MainApp/Portfolio/Content.tsx
@@ -33,6 +33,7 @@ const PortfolioPageContent: FC = () => {
           <AssetAllocation
             walletId={selectedWallet?.__id}
             onRowClick={onAssetClick}
+            withParentIconAtBottom
           />
         </Container>
       </Suspense>


### PR DESCRIPTION
Fixes https://app.clickup.com/t/9002019994/PRF-6398
Fixes https://app.clickup.com/t/9002019994/PRF-6376