### PR TITLE
feat(password-input): enable copy-paste in password-input

### DIFF
--- a/.changeset/young-weeks-buy.md
+++ b/.changeset/young-weeks-buy.md
@@ -1,0 +1,6 @@
+---
+'@cypherock/cysync-ui': patch
+'@cypherock/cysync-desktop': patch
+---
+
+Enabled copy paste feature on the password input fields

--- a/packages/ui/src/components/atoms/Input/PasswordInput.tsx
+++ b/packages/ui/src/components/atoms/Input/PasswordInput.tsx
@@ -28,8 +28,8 @@ export const PasswordInput: FC<PasswordInputProps> = props => {
     <Input
       type={showPassword ? 'text' : 'password'}
       {...props}
-      copyAllowed={false}
-      pasteAllowed={false}
+      copyAllowed
+      pasteAllowed
       postfixIcon={
         showPassword ? (
           <Visibility {...iconProps} />


### PR DESCRIPTION
Enabled Copy Paste Feature on the Password Input fields in cysync app