### PR TITLE
feat: implemented retry button on device busy state

### DIFF
--- a/.changeset/dry-radios-happen.md
+++ b/.changeset/dry-radios-happen.md
@@ -3,4 +3,4 @@
 '@cypherock/cysync-desktop': patch
 ---
 
-Changeset for feat/device-busy-retry
+Implemented Retry Button in Device Busy state

--- a/.changeset/dry-radios-happen.md
+++ b/.changeset/dry-radios-happen.md
@@ -1,0 +1,6 @@
+---
+'@cypherock/cysync-core': patch
+'@cypherock/cysync-desktop': patch
+---
+
+Changeset for feat/device-busy-retry

--- a/packages/cysync-core/src/bgTask/deviceHandlingTask/index.tsx
+++ b/packages/cysync-core/src/bgTask/deviceHandlingTask/index.tsx
@@ -40,7 +40,7 @@ const OnboardingMap: Record<OnboardingStep, string> = {
 };
 
 export const DeviceHandlingTask: React.FC = () => {
-  const { deviceHandlingState, connection } = useDevice();
+  const { deviceHandlingState, connection, reconnectDevice } = useDevice();
   const dispatch = useAppDispatch();
   const navigateTo = useNavigateTo();
   const { deviceAuthenticationDialog, deviceUpdateDialog } =
@@ -77,7 +77,11 @@ export const DeviceHandlingTask: React.FC = () => {
         openErrorDialog({
           error,
           showCloseButton: true,
-          suppressActions: true,
+          suppressActions: false,
+          onRetry: async () => {
+            await reconnectDevice();
+            dispatch(closeAllDialogs());
+          },
         }),
       );
     },


### PR DESCRIPTION
Error dialogue will have retry button if device is in busy state and on clicking that connection will be re-established