### PR TITLE
fix: fixed send continue btn disable bug in coins other than xrp

### DIFF
--- a/packages/coin-support-xrp/src/operations/initializeTransaction/index.ts
+++ b/packages/coin-support-xrp/src/operations/initializeTransaction/index.ts
@@ -22,9 +22,9 @@ export const initializeTransaction = async (
       isFeeBelowMin: false,
       ownOutputAddressNotAllowed: [],
       zeroAmountNotAllowed: false,
-      isAmountBelowXrpReserveAllowed: true,
+      isAmountBelowXrpReserve: false,
       isBalanceBelowXrpReserve: false,
-      isValidDestinationTag: true,
+      isInvalidDestinationTag: false,
     },
     userInputs: {
       outputs: [],

--- a/packages/coin-support-xrp/src/operations/prepareTransaction/index.ts
+++ b/packages/coin-support-xrp/src/operations/prepareTransaction/index.ts
@@ -114,21 +114,19 @@ export const prepareTransaction = async (
     );
   }
 
-  let isAmountBelowXrpReserveAllowed = output.isActivated ?? true;
-  if (!isAmountBelowXrpReserveAllowed) {
-    isAmountBelowXrpReserveAllowed = sendAmount.isGreaterThanOrEqualTo(
-      coin.reserveXrp,
-    );
+  let isAmountBelowXrpReserve = !output.isActivated;
+  if (isAmountBelowXrpReserve) {
+    isAmountBelowXrpReserve = sendAmount.isLessThan(coin.reserveXrp);
   }
 
   const isValidFee = new BigNumber(fees).isGreaterThan(0);
   const isFeeBelowMin =
     isValidFee && new BigNumber(fees).isLessThan(txn.staticData.fees);
 
-  const isValidDestinationTag =
+  const isInvalidDestinationTag =
     output.destinationTag !== undefined
-      ? output.destinationTag < MAX_UNSIGNED_32BIT_INT
-      : true;
+      ? output.destinationTag >= MAX_UNSIGNED_32BIT_INT
+      : false;
 
   return {
     ...txn,
@@ -139,9 +137,9 @@ export const prepareTransaction = async (
       isFeeBelowMin,
       ownOutputAddressNotAllowed: [isOwnOutputAddress],
       zeroAmountNotAllowed: sendAmount.isZero(),
-      isAmountBelowXrpReserveAllowed,
+      isAmountBelowXrpReserve,
       isBalanceBelowXrpReserve,
-      isValidDestinationTag,
+      isInvalidDestinationTag,
     },
     computedData: {
       fees,

--- a/packages/coin-support-xrp/src/operations/transaction.ts
+++ b/packages/coin-support-xrp/src/operations/transaction.ts
@@ -21,9 +21,9 @@ export interface IPreparedXrpTransaction extends IPreparedTransaction {
     isFeeBelowMin: boolean;
     ownOutputAddressNotAllowed: boolean[];
     zeroAmountNotAllowed: boolean;
-    isAmountBelowXrpReserveAllowed: boolean;
+    isAmountBelowXrpReserve: boolean;
     isBalanceBelowXrpReserve: boolean;
-    isValidDestinationTag: boolean;
+    isInvalidDestinationTag: boolean;
   };
   staticData: {
     fees: string;

--- a/packages/cysync-core/src/dialogs/Send/Dialogs/Recipient.tsx
+++ b/packages/cysync-core/src/dialogs/Send/Dialogs/Recipient.tsx
@@ -82,12 +82,12 @@ export const Recipient: React.FC = () => {
         !transaction.validation.zeroAmountNotAllowed &&
         !(transaction.validation as IPreparedXrpTransaction['validation'])
           .isBalanceBelowXrpReserve &&
-        (transaction.validation as IPreparedXrpTransaction['validation'])
-          .isAmountBelowXrpReserveAllowed &&
+        !(transaction.validation as IPreparedXrpTransaction['validation'])
+          .isAmountBelowXrpReserve &&
         !(transaction.validation as IPreparedXrpTransaction['validation'])
           .isFeeBelowMin &&
-        (transaction.validation as IPreparedXrpTransaction['validation'])
-          .isValidDestinationTag,
+        !(transaction.validation as IPreparedXrpTransaction['validation'])
+          .isInvalidDestinationTag,
     );
   }, [transaction]);
 

--- a/packages/cysync-core/src/dialogs/Send/context/index.tsx
+++ b/packages/cysync-core/src/dialogs/Send/context/index.tsx
@@ -669,7 +669,7 @@ export const SendDialogProvider: FC<SendDialogContextProviderProps> = ({
       return lang.strings.send.recipient.amount.balanceBelowXrpReserve;
     }
 
-    if (xrpValdation?.isAmountBelowXrpReserveAllowed === false) {
+    if (xrpValdation?.isAmountBelowXrpReserve) {
       return lang.strings.send.recipient.amount.amountBelowXrpReserve;
     }
 
@@ -678,8 +678,8 @@ export const SendDialogProvider: FC<SendDialogContextProviderProps> = ({
 
   const getDestinationTagError = useCallback(() => {
     if (
-      !(transaction?.validation as IPreparedXrpTransaction['validation'])
-        .isValidDestinationTag
+      (transaction?.validation as IPreparedXrpTransaction['validation'])
+        .isInvalidDestinationTag
     ) {
       return lang.strings.send.recipient.destinationTag.error;
     }


### PR DESCRIPTION
Continue button is disabled for all other coins except XRP

Steps to Reproduce:
  - Initiate send txn of any coin except XRP
  - Fill all details
  - Check for continue button


Actual Behaviour:
  ~ Behaviour currently Seen ~

Expected Behaviour:
  - Txn shouldn't be blocked if all the fields are complete and correct

![image](https://github.com/user-attachments/assets/bd73a825-ad86-42a3-bebb-ceece4ca7200)
