### PR TITLE
fix: added tilde symbol in spendable amount

### DIFF
--- a/packages/cysync-core/src/dialogs/Send/Dialogs/Recipient.tsx
+++ b/packages/cysync-core/src/dialogs/Send/Dialogs/Recipient.tsx
@@ -127,7 +127,7 @@ export const Recipient: React.FC = () => {
           }
           pt={2}
           text={displayText.infoBox}
-          altText={getBalanceToDisplay()}
+          altText={`~${getBalanceToDisplay()}`}
           textVariant="span"
           fontSize={12}
           disabledInnerFlex


### PR DESCRIPTION
Currently ~ is missing as it directly denotes 'x' XRP which is not the exact amount that can be transferred.

Steps to Reproduce:
  - Initiate send txn
  - Check for max spendable amount

Actual Behaviour:
~ Behaviour currently Seen ~
![image](https://github.com/user-attachments/assets/4458e9b6-88fa-4438-8712-b23116cfd732)

Expected Behaviour:
  Add ~ before amount