### PR TITLE
fix: update latest block hash while fetching history

### DIFF
--- a/.changeset/good-scissors-turn.md
+++ b/.changeset/good-scissors-turn.md
@@ -1,0 +1,5 @@
+---
+'@cypherock/coin-support-evm': patch
+---
+
+Fixed sync stuck in infinite loop

--- a/packages/coin-support-evm/src/operations/syncAccount/index.ts
+++ b/packages/coin-support-evm/src/operations/syncAccount/index.ts
@@ -176,25 +176,23 @@ const fetchAndParseContractTransactions = async (params: {
     limit: PER_PAGE_TXN_LIMIT,
   });
 
-  const { transactions, newAccounts } = await mapContractTransactionsForDb({
-    account,
-    transactions: transactionDetails.result,
-    db,
-    existingTransactions,
-  });
+  const { transactions, newAccounts, latestBlock } =
+    await mapContractTransactionsForDb({
+      account,
+      transactions: transactionDetails.result,
+      db,
+      existingTransactions,
+    });
 
   const hasMore = transactionDetails.more;
 
-  const newAfterBlock = Math.max(
-    ...transactions
-      .filter(t => t.status === TransactionStatusMap.success && t.blockHeight)
-      .map(t => t.blockHeight),
-    0,
-  );
-
   onNewAccounts(newAccounts, db);
 
-  return { hasMore, transactions, afterBlock: newAfterBlock };
+  return {
+    hasMore,
+    transactions,
+    afterBlock: Math.max(latestBlock.toNumber(), afterBlock ?? 0),
+  };
 };
 
 const getAddressDetails: IGetAddressDetails<{

--- a/packages/coin-support-evm/src/services/helpers/contractTransactions.ts
+++ b/packages/coin-support-evm/src/services/helpers/contractTransactions.ts
@@ -153,11 +153,16 @@ export const mapContractTransactionsForDb = async (params: {
   account: IAccount;
   transactions: IEvmContractTransactionItem[];
   existingTransactions: ITransaction[];
-}): Promise<{ transactions: ITransaction[]; newAccounts: IAccount[] }> => {
+}): Promise<{
+  transactions: ITransaction[];
+  newAccounts: IAccount[];
+  latestBlock: BigNumber;
+}> => {
   const { account, transactions, db, existingTransactions } = params;
 
   const txns: ITransaction[] = [];
   const newAccountsList: IAccount[] = [];
+  let latestBlock = new BigNumber(0);
 
   for (const txn of transactions) {
     const result = await mapContractTransactionForDb({
@@ -166,9 +171,12 @@ export const mapContractTransactionsForDb = async (params: {
       db,
       existingTransactions,
     });
+    // Update latestBlock regardless of transaction parser result
+    latestBlock = BigNumber.max(latestBlock, new BigNumber(txn.blockNumber));
+
     txns.push(...result.transactions);
     newAccountsList.push(...result.newAccounts);
   }
 
-  return { transactions: txns, newAccounts: newAccountsList };
+  return { transactions: txns, newAccounts: newAccountsList, latestBlock };
 };


### PR DESCRIPTION
- updating the latest block hash even if the the contract is not in supported coin list
- this prevents the sync queue to be stuck in a continous loop
- shifts the latest block responsibility to transaction parser