### PR TITLE
fix: fixed starknet txnhash mismatch, deploy account text, disbale continue btn

### DIFF
--- a/packages/coin-support-starknet/src/operations/broadcastTransaction/index.ts
+++ b/packages/coin-support-starknet/src/operations/broadcastTransaction/index.ts
@@ -16,7 +16,7 @@ import {
   broadcastInvokeTransactionToBlockchain,
   prepareInvokeTransaction,
 } from '../../services';
-import { addHexPrefix } from '../../utils/addHexPrefix';
+import { completeHexHash } from '../../utils/completeHexHash';
 
 export const broadcastTransaction = async (
   params: IBroadcastStarknetTransactionParams,
@@ -50,7 +50,7 @@ export const broadcastTransaction = async (
   });
 
   const parsedTransaction: ITransaction = {
-    hash: addHexPrefix(result.transactionHash),
+    hash: completeHexHash(result.transactionHash),
     fees: feeData.suggestedMaxFee,
     amount,
     status: TransactionStatusMap.pending,

--- a/packages/coin-support-starknet/src/operations/deployAccount/broadcastDeployAccountTransaction.ts
+++ b/packages/coin-support-starknet/src/operations/deployAccount/broadcastDeployAccountTransaction.ts
@@ -21,7 +21,7 @@ import {
   getBalance,
   prepareDeployAccountTransaction,
 } from '../../services';
-import { addHexPrefix } from '../../utils/addHexPrefix';
+import { completeHexHash } from '../../utils/completeHexHash';
 
 export const broadcastDeployAccountTransaction = async (
   params: IBroadcastStarknetDeployAccountTransactionParams,
@@ -50,7 +50,7 @@ export const broadcastDeployAccountTransaction = async (
   });
 
   const parsedTransaction: ITransaction = {
-    hash: addHexPrefix(result.transactionHash),
+    hash: completeHexHash(result.transactionHash),
     fees: feeData.suggestedMaxFee,
     amount: '0',
     status: TransactionStatusMap.pending,

--- a/packages/coin-support-starknet/src/operations/syncAccount/index.ts
+++ b/packages/coin-support-starknet/src/operations/syncAccount/index.ts
@@ -14,7 +14,7 @@ import { ISyncStarknetAccountsParams } from './types';
 
 import { STRK_TOKEN_CONTRACT } from '../../constants';
 import * as services from '../../services';
-import { addHexPrefix } from '../../utils/addHexPrefix';
+import { completeHexHash } from '../../utils/completeHexHash';
 import { IStarknetAccount } from '../types';
 
 const PER_PAGE_TXN_LIMIT = 100;
@@ -33,7 +33,7 @@ const parseTransaction = (
     assetId: account.assetId,
     familyId: account.familyId,
     parentAssetId: account.parentAssetId,
-    hash: addHexPrefix(txn.transactionHash),
+    hash: completeHexHash(txn.transactionHash),
     confirmations: 1,
     fees: txn.transactionFee,
     amount,

--- a/packages/coin-support-starknet/src/utils/addHexPrefix.ts
+++ b/packages/coin-support-starknet/src/utils/addHexPrefix.ts
@@ -1,8 +1,0 @@
-const removeHexPrefix = (hex: string) => hex.replace(/^0x/i, '');
-
-export const addHexPrefix = (hex: string) => {
-  let hexPrefix = '0x';
-  if (hex.length % 2) hexPrefix = '0x0';
-
-  return `${hexPrefix}${removeHexPrefix(hex)}`;
-};

--- a/packages/coin-support-starknet/src/utils/completeHexHash.ts
+++ b/packages/coin-support-starknet/src/utils/completeHexHash.ts
@@ -1,0 +1,16 @@
+const HASH_LENGTH = 64; // 32 BYTES
+
+const removeHexPrefix = (hex: string) => hex.replace(/^0x/i, '');
+
+export const completeHexHash = (hex: string) => {
+  const inputHexHash = removeHexPrefix(hex);
+  let remainingChars = HASH_LENGTH - inputHexHash.length;
+
+  let hexPrefix = '0x';
+  while (remainingChars) {
+    hexPrefix += '0';
+    remainingChars -= 1;
+  }
+
+  return `${hexPrefix}${inputHexHash}`;
+};

--- a/packages/coin-support-starknet/src/utils/completeHexHash.ts
+++ b/packages/coin-support-starknet/src/utils/completeHexHash.ts
@@ -1,16 +1,5 @@
-const HASH_LENGTH = 64; // 32 BYTES
-
 const removeHexPrefix = (hex: string) => hex.replace(/^0x/i, '');
 
-export const completeHexHash = (hex: string) => {
-  const inputHexHash = removeHexPrefix(hex);
-  let remainingChars = HASH_LENGTH - inputHexHash.length;
-
-  let hexPrefix = '0x';
-  while (remainingChars) {
-    hexPrefix += '0';
-    remainingChars -= 1;
-  }
-
-  return `${hexPrefix}${inputHexHash}`;
+export const completeHexHash = (input: string, maxLength = 64) => {
+  return "0x" + removeHexPrefix(input).padStart(maxLength, "0");
 };

--- a/packages/coin-support-starknet/src/utils/completeHexHash.ts
+++ b/packages/coin-support-starknet/src/utils/completeHexHash.ts
@@ -1,5 +1,4 @@
 const removeHexPrefix = (hex: string) => hex.replace(/^0x/i, '');
 
-export const completeHexHash = (input: string, maxLength = 64) => {
-  return "0x" + removeHexPrefix(input).padStart(maxLength, "0");
-};
+export const completeHexHash = (input: string, maxLength = 64) =>
+  `0x${removeHexPrefix(input).padStart(maxLength, '0')}`;

--- a/packages/coin-support-starknet/src/utils/deriveAddress.ts
+++ b/packages/coin-support-starknet/src/utils/deriveAddress.ts
@@ -1,6 +1,6 @@
 import { starknetCoinList } from '@cypherock/coins';
 
-import { addHexPrefix } from './addHexPrefix';
+import { completeHexHash } from './completeHexHash';
 import { getCoinSupportStarknetLib } from './starknetLib';
 
 export const deriveAddress = (publicKey: string, assetId: string) => {
@@ -12,5 +12,5 @@ export const deriveAddress = (publicKey: string, assetId: string) => {
     constructorAXCallData,
     0,
   );
-  return addHexPrefix(accountAXAddress);
+  return completeHexHash(accountAXAddress);
 };

--- a/packages/cysync-core-constants/src/i18n/lang/ar-AE.json
+++ b/packages/cysync-core-constants/src/i18n/lang/ar-AE.json
@@ -379,7 +379,7 @@
     }
   },
   "deployAccount": {
-    "title": "Deploy Account",
+    "title": "Account Deployment",
     "x1Vault": {
       "title": "Follow instructions on the X1 Vault",
       "actions": {

--- a/packages/cysync-core-constants/src/i18n/lang/de-DE.json
+++ b/packages/cysync-core-constants/src/i18n/lang/de-DE.json
@@ -379,7 +379,7 @@
     }
   },
   "deployAccount": {
-    "title": "Deploy Account",
+    "title": "Account Deployment",
     "x1Vault": {
       "title": "Follow instructions on the X1 Vault",
       "actions": {

--- a/packages/cysync-core-constants/src/i18n/lang/en.json
+++ b/packages/cysync-core-constants/src/i18n/lang/en.json
@@ -379,7 +379,7 @@
     }
   },
   "deployAccount": {
-    "title": "Deploy Account",
+    "title": "Account Deployment",
     "x1Vault": {
       "title": "Follow instructions on the X1 Vault",
       "actions": {

--- a/packages/cysync-core-constants/src/i18n/lang/id-ID.json
+++ b/packages/cysync-core-constants/src/i18n/lang/id-ID.json
@@ -379,7 +379,7 @@
     }
   },
   "deployAccount": {
-    "title": "Deploy Account",
+    "title": "Account Deployment",
     "x1Vault": {
       "title": "Follow instructions on the X1 Vault",
       "actions": {

--- a/packages/cysync-core-constants/src/i18n/lang/zh-CN.json
+++ b/packages/cysync-core-constants/src/i18n/lang/zh-CN.json
@@ -423,7 +423,7 @@
     }
   },
   "deployAccount": {
-    "title": "Deploy Account",
+    "title": "Account Deployment",
     "x1Vault": {
       "title": "Follow instructions on the X1 Vault",
       "actions": {

--- a/packages/cysync-core/src/dialogs/DeployAccount/index.tsx
+++ b/packages/cysync-core/src/dialogs/DeployAccount/index.tsx
@@ -58,7 +58,7 @@ export const DeployAccountFlow: FC = () => {
               .filter(t => !t.dontShowOnMilestone)
               .map(t => t.name)}
             activeTab={currentTab}
-            heading={lang.strings.send.title}
+            heading={lang.strings.deployAccount.title}
           />
           <WalletDialogMainContainer>
             <DialogBoxBody

--- a/packages/cysync-core/src/dialogs/Send/Dialogs/SelectionDialog.tsx
+++ b/packages/cysync-core/src/dialogs/Send/Dialogs/SelectionDialog.tsx
@@ -114,6 +114,7 @@ export const SelectionDialog: React.FC = () => {
       <DialogBoxFooter>
         <Button
           variant="primary"
+          isLoading={isLoading}
           disabled={!selectedAccount || !selectedWallet || isLoading}
           autoFocus={Boolean(defaultWalletId) && Boolean(defaultAccountId)}
           onClick={e => {

--- a/packages/cysync-core/src/dialogs/Send/Dialogs/SelectionDialog.tsx
+++ b/packages/cysync-core/src/dialogs/Send/Dialogs/SelectionDialog.tsx
@@ -32,8 +32,6 @@ export const SelectionDialog: React.FC = () => {
     defaultAccountId,
   } = useSendDialog();
 
-  const [loadingNext, setLoadingNext] = useState(false);
-
   const dialogText = lang.strings.send.source;
   const buttonText = lang.strings.buttons;
 
@@ -63,10 +61,11 @@ export const SelectionDialog: React.FC = () => {
     [allAccounts, handleAccountChange],
   );
 
+  const [movingForward, setMovingForward] = useState(false);
   const handleContinue = useCallback(() => {
-    setLoadingNext(true);
+    setMovingForward(true);
     onSelectionDialogNext();
-  }, [onSelectionDialogNext, setLoadingNext]);
+  }, [onSelectionDialogNext, setMovingForward]);
 
   return (
     <DialogBox width={500}>
@@ -115,8 +114,7 @@ export const SelectionDialog: React.FC = () => {
       <DialogBoxFooter>
         <Button
           variant="primary"
-          isLoading={loadingNext}
-          disabled={!selectedAccount || !selectedWallet}
+          disabled={!selectedAccount || !selectedWallet || movingForward}
           autoFocus={Boolean(defaultWalletId) && Boolean(defaultAccountId)}
           onClick={e => {
             e.preventDefault();

--- a/packages/cysync-core/src/dialogs/Send/Dialogs/SelectionDialog.tsx
+++ b/packages/cysync-core/src/dialogs/Send/Dialogs/SelectionDialog.tsx
@@ -61,11 +61,11 @@ export const SelectionDialog: React.FC = () => {
     [allAccounts, handleAccountChange],
   );
 
-  const [movingForward, setMovingForward] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
   const handleContinue = useCallback(() => {
-    setMovingForward(true);
+    setIsLoading(true);
     onSelectionDialogNext();
-  }, [onSelectionDialogNext, setMovingForward]);
+  }, [onSelectionDialogNext, setIsLoading]);
 
   return (
     <DialogBox width={500}>
@@ -114,7 +114,7 @@ export const SelectionDialog: React.FC = () => {
       <DialogBoxFooter>
         <Button
           variant="primary"
-          disabled={!selectedAccount || !selectedWallet || movingForward}
+          disabled={!selectedAccount || !selectedWallet || isLoading}
           autoFocus={Boolean(defaultWalletId) && Boolean(defaultAccountId)}
           onClick={e => {
             e.preventDefault();


### PR DESCRIPTION
- fixed txn hash mismatch by prepending appropriate number of zeroes
- 'send' changed to 'Account Deployment'
- disable selection tab continue btn (instead of showing loading) while checking whether account is deployed or not