### PR TITLE
fix: simulation failing issue, sendMax txn failing issue

### DIFF
--- a/.changeset/plenty-poets-raise.md
+++ b/.changeset/plenty-poets-raise.md
@@ -1,6 +1,6 @@
 ---
-'@cypherock/coin-support-solana': minor
-'@cypherock/cysync-core': minor
+'@cypherock/coin-support-solana': patch
+'@cypherock/cysync-core': patch
 ---
 
 fixed solana send max issue and added spendable balance(balance - rentExempt) in solana account

--- a/.changeset/plenty-poets-raise.md
+++ b/.changeset/plenty-poets-raise.md
@@ -1,0 +1,6 @@
+---
+'@cypherock/coin-support-solana': minor
+'@cypherock/cysync-core': minor
+---
+
+fixed solana send max issue and added spendable balance(balance - rentExempt) in solana account

--- a/packages/coin-support-solana/src/operations/createAccounts/index.ts
+++ b/packages/coin-support-solana/src/operations/createAccounts/index.ts
@@ -19,6 +19,7 @@ import {
 } from './types';
 
 import * as services from '../../services';
+import { BigNumber } from '@cypherock/cysync-utils';
 
 const DERIVATION_PATH_LIMIT = 30;
 
@@ -63,10 +64,19 @@ const createAccountFromAddress: IMakeCreateAccountsObservableParams<SolanaApp>['
     const coin = solanaCoinList[params.coinId];
     const name = `${coin.name} ${addressDetails.index + 1}`;
 
+    const { address, balance } = addressDetails;
+    const spendableBalance = BigNumber.max(
+      0,
+      new BigNumber(balance).minus(
+        await services.getNativeAccountRentExemptFees(address, coin.id),
+      ),
+    ).toString();
+
     const account: ICreatedSolanaAccount = {
       name,
-      xpubOrAddress: addressDetails.address,
+      xpubOrAddress: address,
       balance: addressDetails.balance,
+      spendableBalance,
       unit: coin.units[0].abbr,
       derivationPath: addressDetails.derivationPath,
       type: AccountTypeMap.account,

--- a/packages/coin-support-solana/src/operations/initializeTransaction/index.ts
+++ b/packages/coin-support-solana/src/operations/initializeTransaction/index.ts
@@ -3,7 +3,7 @@ import { getAccountAndCoin } from '@cypherock/coin-support-utils';
 import { solanaCoinList } from '@cypherock/coins';
 import { BigNumber } from '@cypherock/cysync-utils';
 
-import { getFees } from '../../services';
+import { getFees, getRentExemptFees } from '../../services';
 
 import { IPreparedSolanaTransaction } from '../transaction';
 import { AccountTypeMap } from '@cypherock/db-interfaces';
@@ -75,6 +75,11 @@ export const initializeTransaction = async (
     )
     .toFixed(0);
 
+  let rentExempt = '0';
+  if (!isTokenAccount) {
+    rentExempt = await getRentExemptFees(0, coin.id); // For a new native solana account, account data length is 0
+  }
+
   return {
     accountId,
     validation: {
@@ -85,6 +90,7 @@ export const initializeTransaction = async (
       zeroAmountNotAllowed: false,
       isRentExemptFeeRequired: false,
       isBalanceBelowRentExempt: false,
+      isAmountBelowRentExempt: false,
     },
     userInputs: {
       outputs: [],
@@ -92,6 +98,7 @@ export const initializeTransaction = async (
     },
     staticData: {
       baseFee,
+      rentExempt,
     },
     computedData: {
       output: { address: '', amount: '0' },

--- a/packages/coin-support-solana/src/operations/initializeTransaction/index.ts
+++ b/packages/coin-support-solana/src/operations/initializeTransaction/index.ts
@@ -89,7 +89,6 @@ export const initializeTransaction = async (
       ownOutputAddressNotAllowed: [],
       zeroAmountNotAllowed: false,
       isRentExemptFeeRequired: false,
-      isBalanceBelowRentExempt: false,
       isAmountBelowRentExempt: false,
     },
     userInputs: {

--- a/packages/coin-support-solana/src/operations/initializeTransaction/index.ts
+++ b/packages/coin-support-solana/src/operations/initializeTransaction/index.ts
@@ -3,11 +3,7 @@ import { getAccountAndCoin } from '@cypherock/coin-support-utils';
 import { solanaCoinList } from '@cypherock/coins';
 import { BigNumber } from '@cypherock/cysync-utils';
 
-import {
-  getFees,
-  getPriorityFees,
-  getSimulationComputeUnits,
-} from '../../services';
+import { getFees } from '../../services';
 
 import { IPreparedSolanaTransaction } from '../transaction';
 import { AccountTypeMap } from '@cypherock/db-interfaces';
@@ -18,7 +14,6 @@ import {
   ICustomSolanaTransferInstruction,
   InstructionType,
 } from '../../utils';
-import logger from '../../utils/logger';
 
 export const initializeTransaction = async (
   params: IInitializeTransactionParams,
@@ -65,26 +60,12 @@ export const initializeTransaction = async (
     coin.id,
   );
 
-  let computeUnits = 200_000; // Fallback value for computeunits
-  try {
-    computeUnits = await getSimulationComputeUnits(
-      transaction
-        .serialize({ requireAllSignatures: false, verifySignatures: false })
-        .toString('base64'),
-      coin.id,
-    );
-  } catch (e) {
-    logger.warn('Failed to simulate transaction');
-    logger.warn(JSON.stringify(e));
-  }
+  // Not needed the calculation from blockchain for inital values. Just use max/default values
+  // Max compute units possible for our case (setComputeUnitPrice + setComputeUnitLimit + createAccount + transferChecked)
+  const computeUnits = 10_000;
 
-  let computeUnitPriceMicroLamports = 0; // Fallback value for computeprice
-  try {
-    computeUnitPriceMicroLamports = await getPriorityFees(coin.id);
-  } catch (e) {
-    logger.warn('Failed to fetch priority fees from server');
-    logger.warn(JSON.stringify(e));
-  }
+  // Default price, taken from trezor
+  const computeUnitPriceMicroLamports = 100_000;
 
   fees = new BigNumber(fees)
     .plus(

--- a/packages/coin-support-solana/src/operations/initializeTransaction/index.ts
+++ b/packages/coin-support-solana/src/operations/initializeTransaction/index.ts
@@ -55,7 +55,7 @@ export const initializeTransaction = async (
     instructions,
   );
 
-  let fees = await getFees(
+  const baseFee = await getFees(
     transaction.serializeMessage().toString('base64'),
     coin.id,
   );
@@ -67,7 +67,7 @@ export const initializeTransaction = async (
   // Default price, taken from trezor
   const computeUnitPriceMicroLamports = 100_000;
 
-  fees = new BigNumber(fees)
+  const fees = new BigNumber(baseFee)
     .plus(
       new BigNumber(computeUnitPriceMicroLamports)
         .dividedBy(10 ** 6)
@@ -90,7 +90,7 @@ export const initializeTransaction = async (
       isSendAll: false,
     },
     staticData: {
-      fees,
+      baseFee,
     },
     computedData: {
       output: { address: '', amount: '0' },

--- a/packages/coin-support-solana/src/operations/initializeTransaction/index.ts
+++ b/packages/coin-support-solana/src/operations/initializeTransaction/index.ts
@@ -84,6 +84,7 @@ export const initializeTransaction = async (
       ownOutputAddressNotAllowed: [],
       zeroAmountNotAllowed: false,
       isRentExemptFeeRequired: false,
+      isBalanceBelowRentExempt: false,
     },
     userInputs: {
       outputs: [],

--- a/packages/coin-support-solana/src/operations/prepareTransaction/index.ts
+++ b/packages/coin-support-solana/src/operations/prepareTransaction/index.ts
@@ -75,7 +75,6 @@ const estimateFees = async (
     assetId,
     address,
     instructions,
-    { useMinimumAmounts: true },
   );
 
   let fees = await getFees(
@@ -83,7 +82,7 @@ const estimateFees = async (
     assetId,
   );
 
-  let computeUnits = 200_000; // Fallback value for computeunits
+  let computeUnits = 10_000; // Fallback value for computeunits
   try {
     computeUnits = await getSimulationComputeUnits(
       transaction
@@ -96,7 +95,7 @@ const estimateFees = async (
     logger.warn(JSON.stringify(e));
   }
 
-  let computeUnitPriceMicroLamports = 0; // Fallback value for computeprice
+  let computeUnitPriceMicroLamports = 100_000; // Fallback value for computeprice
   try {
     computeUnitPriceMicroLamports = await getPriorityFees(assetId);
   } catch (e) {

--- a/packages/coin-support-solana/src/operations/prepareTransaction/index.ts
+++ b/packages/coin-support-solana/src/operations/prepareTransaction/index.ts
@@ -129,6 +129,10 @@ export const prepareTransaction = async (
     new Error('Solana transaction requires exactly 1 output'),
   );
 
+  const spendableBalance = new BigNumber(
+    new BigNumber(account.spendableBalance ?? account.balance).toFixed(0),
+  );
+
   const outputsAddresses = validateAddresses(params, coin);
   const output = { ...txn.userInputs.outputs[0] };
   // Amount shouldn't have any decimal value as it's in lowest unit
@@ -174,14 +178,12 @@ export const prepareTransaction = async (
     output.address !== '' &&
     outputsAddresses?.[0]
   ) {
-    const amountToSend = sendAmount.isNaN()
-      ? new BigNumber(new BigNumber(account.balance).toFixed(0)).toNumber()
-      : sendAmount.toNumber();
+    const amountToSend = sendAmount.isNaN() ? spendableBalance : sendAmount;
 
     if (tokenDetails) {
       const instruction: ICustomSolanaTransferCheckedInstruction = {
         type: InstructionType.transferChecked,
-        amount: amountToSend,
+        amount: amountToSend.toNumber(),
         recipient: output.address,
         mintAddress: tokenDetails.address,
         decimals: tokenDetails.decimals,
@@ -190,7 +192,7 @@ export const prepareTransaction = async (
     } else {
       const instruction: ICustomSolanaTransferInstruction = {
         type: InstructionType.transfer,
-        amount: amountToSend,
+        amount: amountToSend.minus(txn.staticData.baseFee).toNumber(),
         recipient: output.address,
       };
       instructions.push(instruction);
@@ -212,7 +214,7 @@ export const prepareTransaction = async (
   let hasEnoughBalance: boolean;
 
   if (txn.userInputs.isSendAll) {
-    sendAmount = new BigNumber(account.balance);
+    sendAmount = spendableBalance;
 
     if (!isTokenAccount) sendAmount = BigNumber.max(sendAmount.minus(fee), 0);
 
@@ -226,10 +228,8 @@ export const prepareTransaction = async (
 
   hasEnoughBalance = isTokenAccount
     ? new BigNumber(parentAccount?.balance ?? 0).isGreaterThan(fee) &&
-      new BigNumber(account.balance).isGreaterThanOrEqualTo(sendAmount)
-    : new BigNumber(account.balance).isGreaterThanOrEqualTo(
-        sendAmount.plus(fee),
-      );
+      spendableBalance.isGreaterThanOrEqualTo(sendAmount)
+    : spendableBalance.isGreaterThanOrEqualTo(sendAmount.plus(fee));
 
   hasEnoughBalance =
     new BigNumber(txn.userInputs.outputs[0].amount).isNaN() || hasEnoughBalance;

--- a/packages/coin-support-solana/src/operations/prepareTransaction/index.ts
+++ b/packages/coin-support-solana/src/operations/prepareTransaction/index.ts
@@ -218,7 +218,16 @@ export const prepareTransaction = async (
 
     if (!isTokenAccount) sendAmount = BigNumber.max(sendAmount.minus(fee), 0);
 
-    output.amount = new BigNumber(sendAmount.toFixed(0)).toString(10);
+    output.amount = sendAmount.toFixed(0);
+
+    // update the amount in transfer instruction
+    if (instructions.length > 0) {
+      (
+        instructions[instructions.length - 1] as
+          | ICustomSolanaTransferInstruction
+          | ICustomSolanaTransferCheckedInstruction
+      ).amount = new BigNumber(output.amount).toNumber();
+    }
 
     // update userInput so that the max amount is editable & not reset to 0
     txn.userInputs.outputs[0].amount = output.amount;

--- a/packages/coin-support-solana/src/operations/prepareTransaction/index.ts
+++ b/packages/coin-support-solana/src/operations/prepareTransaction/index.ts
@@ -1,7 +1,7 @@
 import { getAccountAndCoin } from '@cypherock/coin-support-utils';
 import { solanaCoinList, ICoinInfo, ISolanaSplToken } from '@cypherock/coins';
 import { assert, BigNumber } from '@cypherock/cysync-utils';
-import { AccountTypeMap, IAccount } from '@cypherock/db-interfaces';
+import { AccountTypeMap } from '@cypherock/db-interfaces';
 
 import {
   constructTransaction,
@@ -53,7 +53,6 @@ const validateAddresses = (
 };
 
 const checkIfRecipientTokenAccountExists = async (
-  account: IAccount,
   recipientAddress: string,
   assetId: string,
   mintAddress: string,
@@ -133,8 +132,31 @@ export const prepareTransaction = async (
     new BigNumber(account.spendableBalance ?? account.balance).toFixed(0),
   );
 
+  const isTokenAccount = account.type === AccountTypeMap.subAccount;
+  let tokenDetails: ISolanaSplToken | undefined;
+  if (isTokenAccount)
+    tokenDetails =
+      solanaCoinList[account.parentAssetId].tokens[account.assetId];
+
   const outputsAddresses = validateAddresses(params, coin);
-  const output = { ...txn.userInputs.outputs[0] };
+  let doesExist: boolean | undefined;
+  if (txn.userInputs.outputs[0].address === txn.computedData.output.address) {
+    doesExist = txn.computedData.output.doesExist;
+  }
+
+  const output = { ...txn.userInputs.outputs[0], doesExist };
+
+  if (output.address && outputsAddresses[0] && output.doesExist === undefined) {
+    output.doesExist = tokenDetails
+      ? await checkIfRecipientTokenAccountExists(
+          output.address,
+          coin.id,
+          tokenDetails.address,
+        )
+      : await doesAccountExist(output.address, account.assetId);
+    txn.computedData.output.doesExist = output.doesExist;
+  }
+
   // Amount shouldn't have any decimal value as it's in lowest unit
   output.amount = new BigNumber(output.amount).toFixed(0);
 
@@ -142,22 +164,9 @@ export const prepareTransaction = async (
 
   const instructions: ICustomSolanaInstruction[] = [];
 
-  const isTokenAccount = account.type === AccountTypeMap.subAccount;
-  let tokenDetails: ISolanaSplToken | undefined;
-  if (isTokenAccount)
-    tokenDetails =
-      solanaCoinList[account.parentAssetId].tokens[account.assetId];
-
   let rentExemptFees = new BigNumber(0);
   if (tokenDetails && output.address !== '' && outputsAddresses?.[0]) {
-    const doesExist = await checkIfRecipientTokenAccountExists(
-      account,
-      output.address,
-      coin.id,
-      tokenDetails.address,
-    );
-
-    if (!doesExist) {
+    if (output.doesExist === false) {
       rentExemptFees = new BigNumber(
         await getTokenAccountRentExemptFees(coin.id),
       );
@@ -253,6 +262,11 @@ export const prepareTransaction = async (
     );
   }
 
+  let isAmountBelowRentExempt = false;
+  if (!isTokenAccount && output.doesExist === false) {
+    isAmountBelowRentExempt = sendAmount.isLessThan(txn.staticData.rentExempt);
+  }
+
   return {
     ...txn,
     validation: {
@@ -263,6 +277,7 @@ export const prepareTransaction = async (
       zeroAmountNotAllowed: false,
       isRentExemptFeeRequired: !rentExemptFees.isZero(),
       isBalanceBelowRentExempt,
+      isAmountBelowRentExempt,
     },
     computedData: {
       fees: fee.toString(),

--- a/packages/coin-support-solana/src/operations/prepareTransaction/index.ts
+++ b/packages/coin-support-solana/src/operations/prepareTransaction/index.ts
@@ -236,12 +236,22 @@ export const prepareTransaction = async (
   const isValidFee = fee.isGreaterThan(0);
 
   hasEnoughBalance = isTokenAccount
-    ? new BigNumber(parentAccount?.balance ?? 0).isGreaterThan(fee) &&
+    ? new BigNumber(
+        parentAccount?.spendableBalance ?? parentAccount?.balance ?? 0,
+      ).isGreaterThan(fee) &&
       spendableBalance.isGreaterThanOrEqualTo(sendAmount)
     : spendableBalance.isGreaterThanOrEqualTo(sendAmount.plus(fee));
 
   hasEnoughBalance =
     new BigNumber(txn.userInputs.outputs[0].amount).isNaN() || hasEnoughBalance;
+
+  let isBalanceBelowRentExempt = false;
+  if (!isTokenAccount && hasEnoughBalance) {
+    isBalanceBelowRentExempt = !(
+      sendAmount.isNaN() ||
+      spendableBalance.isGreaterThanOrEqualTo(sendAmount.plus(fee))
+    );
+  }
 
   return {
     ...txn,
@@ -252,6 +262,7 @@ export const prepareTransaction = async (
       ownOutputAddressNotAllowed: [],
       zeroAmountNotAllowed: false,
       isRentExemptFeeRequired: !rentExemptFees.isZero(),
+      isBalanceBelowRentExempt,
     },
     computedData: {
       fees: fee.toString(),

--- a/packages/coin-support-solana/src/operations/prepareTransaction/index.ts
+++ b/packages/coin-support-solana/src/operations/prepareTransaction/index.ts
@@ -254,14 +254,6 @@ export const prepareTransaction = async (
   hasEnoughBalance =
     new BigNumber(txn.userInputs.outputs[0].amount).isNaN() || hasEnoughBalance;
 
-  let isBalanceBelowRentExempt = false;
-  if (!isTokenAccount && hasEnoughBalance) {
-    isBalanceBelowRentExempt = !(
-      sendAmount.isNaN() ||
-      spendableBalance.isGreaterThanOrEqualTo(sendAmount.plus(fee))
-    );
-  }
-
   let isAmountBelowRentExempt = false;
   if (!isTokenAccount && output.doesExist === false) {
     isAmountBelowRentExempt = sendAmount.isLessThan(txn.staticData.rentExempt);
@@ -276,7 +268,6 @@ export const prepareTransaction = async (
       ownOutputAddressNotAllowed: [],
       zeroAmountNotAllowed: false,
       isRentExemptFeeRequired: !rentExemptFees.isZero(),
-      isBalanceBelowRentExempt,
       isAmountBelowRentExempt,
     },
     computedData: {

--- a/packages/coin-support-solana/src/operations/syncAccount/index.ts
+++ b/packages/coin-support-solana/src/operations/syncAccount/index.ts
@@ -21,10 +21,16 @@ import {
   mapTokenTransactionsForDb,
   mapTransactionsForDb,
 } from '../../utils';
-import { getTransactions, getBalance, getTokenBalance } from '../../services';
+import {
+  getTransactions,
+  getBalance,
+  getTokenBalance,
+  getNativeAccountRentExemptFees,
+} from '../../services';
 import { ISolanaAccount } from '../types';
 
 import { ISolanaSplTokenAccount, ISyncSolanaAccountsParams } from './types';
+import { BigNumber } from '@cypherock/cysync-utils';
 
 // Solana transaction are fetched via individual calls, therefore the limit is set relatively low to prevent server timeout.
 const PER_PAGE_TXN_LIMIT = 25;
@@ -126,12 +132,14 @@ const fetchAndParseTransactions = async (params: {
 
 const getAddressDetails: IGetAddressDetails<{
   updatedBalance?: string;
+  updatedSpendableBalance?: string;
   updatedLatestTransactionHash?: string;
   afterTransactionHash?: string;
   beforeTransactionHash?: string;
 }> = async ({ db, account, iterationContext }) => {
   let {
     updatedBalance,
+    updatedSpendableBalance,
     updatedLatestTransactionHash,
     afterTransactionHash,
     beforeTransactionHash,
@@ -154,6 +162,13 @@ const getAddressDetails: IGetAddressDetails<{
     updatedBalance ??= await getTokenBalance(address, account.parentAssetId);
   } else {
     updatedBalance ??= await getBalance(address, account.parentAssetId);
+
+    updatedSpendableBalance ??= BigNumber.max(
+      0,
+      new BigNumber(updatedBalance).minus(
+        await getNativeAccountRentExemptFees(address, account.assetId),
+      ),
+    ).toString();
   }
 
   afterTransactionHash ??= (account as ISolanaAccount | ISolanaSplTokenAccount)
@@ -176,6 +191,7 @@ const getAddressDetails: IGetAddressDetails<{
 
   const updatedAccountInfo: Partial<ISolanaAccount> = {
     balance: updatedBalance,
+    spendableBalance: updatedSpendableBalance,
     extraData: {
       ...account.extraData,
       latestTransactionHash:
@@ -191,6 +207,7 @@ const getAddressDetails: IGetAddressDetails<{
       afterTransactionHash,
       beforeTransactionHash,
       updatedBalance,
+      updatedSpendableBalance,
       updatedLatestTransactionHash,
     },
   };

--- a/packages/coin-support-solana/src/operations/transaction.ts
+++ b/packages/coin-support-solana/src/operations/transaction.ts
@@ -16,7 +16,6 @@ export interface IPreparedSolanaTransaction extends IPreparedTransaction {
     ownOutputAddressNotAllowed: boolean[];
     zeroAmountNotAllowed: boolean;
     isRentExemptFeeRequired: boolean;
-    isBalanceBelowRentExempt: boolean;
     isAmountBelowRentExempt: boolean;
   };
   staticData: {

--- a/packages/coin-support-solana/src/operations/transaction.ts
+++ b/packages/coin-support-solana/src/operations/transaction.ts
@@ -16,6 +16,7 @@ export interface IPreparedSolanaTransaction extends IPreparedTransaction {
     ownOutputAddressNotAllowed: boolean[];
     zeroAmountNotAllowed: boolean;
     isRentExemptFeeRequired: boolean;
+    isBalanceBelowRentExempt: boolean;
   };
   staticData: {
     baseFee: string;

--- a/packages/coin-support-solana/src/operations/transaction.ts
+++ b/packages/coin-support-solana/src/operations/transaction.ts
@@ -17,12 +17,16 @@ export interface IPreparedSolanaTransaction extends IPreparedTransaction {
     zeroAmountNotAllowed: boolean;
     isRentExemptFeeRequired: boolean;
     isBalanceBelowRentExempt: boolean;
+    isAmountBelowRentExempt: boolean;
   };
   staticData: {
     baseFee: string;
+    rentExempt: string;
   };
   computedData: {
-    output: IPreparedTransactionOutput;
+    output: IPreparedTransactionOutput & {
+      doesExist?: boolean;
+    };
     fees: string;
     instructions: ICustomSolanaInstruction[];
     computeUnits: number;

--- a/packages/coin-support-solana/src/operations/transaction.ts
+++ b/packages/coin-support-solana/src/operations/transaction.ts
@@ -18,7 +18,7 @@ export interface IPreparedSolanaTransaction extends IPreparedTransaction {
     isRentExemptFeeRequired: boolean;
   };
   staticData: {
-    fees: string;
+    baseFee: string;
   };
   computedData: {
     output: IPreparedTransactionOutput;

--- a/packages/coin-support-solana/src/services/api/transaction.ts
+++ b/packages/coin-support-solana/src/services/api/transaction.ts
@@ -4,6 +4,7 @@ import { assert, makePostRequest } from '@cypherock/cysync-utils';
 import { ISolanaTransactionResult } from './types';
 
 import { config } from '../../config';
+import { getAccountDataLength } from './wallet';
 
 const baseURL = `${config.API_CYPHEROCK}/solana/transaction`;
 
@@ -15,9 +16,6 @@ const baseURL = `${config.API_CYPHEROCK}/solana/transaction`;
  * https://spl.solana.com/token#finding-all-token-accounts-for-a-specific-mint
  */
 const TOKEN_ACCOUNT_DATA_LENGTH = 165;
-
-// Get the accountInfo of any native account, the length of accountInfo.value.data[0] is 0
-const NATIVE_ACCOUNT_DATA_LENGTH = 0;
 
 export const getTransactions = async (params: {
   address: string;
@@ -140,8 +138,10 @@ export const getRentExemptFees = async (
 export const getTokenAccountRentExemptFees = async (assetId: string) =>
   getRentExemptFees(TOKEN_ACCOUNT_DATA_LENGTH, assetId);
 
-export const getNativeAccountRentExemptFees = async (assetId: string) =>
-  getRentExemptFees(NATIVE_ACCOUNT_DATA_LENGTH, assetId);
+export const getNativeAccountRentExemptFees = async (
+  address: string,
+  assetId: string,
+) => getRentExemptFees(await getAccountDataLength(address, assetId), assetId);
 
 export const broadcastTransactionToBlockchain = async (
   transaction: string,

--- a/packages/coin-support-solana/src/services/api/transaction.ts
+++ b/packages/coin-support-solana/src/services/api/transaction.ts
@@ -16,6 +16,9 @@ const baseURL = `${config.API_CYPHEROCK}/solana/transaction`;
  */
 const TOKEN_ACCOUNT_DATA_LENGTH = 165;
 
+// Get the accountInfo of any native account, the length of accountInfo.value.data[0] is 0
+const NATIVE_ACCOUNT_DATA_LENGTH = 0;
+
 export const getTransactions = async (params: {
   address: string;
   assetId: string;
@@ -77,7 +80,7 @@ export const getSimulationComputeUnits = async (
 
   const response = await makePostRequest(url, query);
 
-  const units = response.data?.units ?? 0;
+  const units = Number(response.data?.units ?? 0);
 
   if (typeof units !== 'number')
     throw new Error(
@@ -109,13 +112,16 @@ export const getPriorityFees = async (
   return priorityFees;
 };
 
-export const getTokenAccountRentExemptFees = async (assetId: string) => {
+export const getRentExemptFees = async (
+  accountDataLength: number,
+  assetId: string,
+) => {
   const url = `${baseURL}/rent-exempt-fee`;
 
   const query: Record<string, any> = {
     responseType: 'v2',
     network: solanaCoinList[assetId].network,
-    accountDataLength: TOKEN_ACCOUNT_DATA_LENGTH,
+    accountDataLength,
   };
 
   const response = await makePostRequest(url, query);
@@ -130,6 +136,12 @@ export const getTokenAccountRentExemptFees = async (assetId: string) => {
 
   return rentExemptFees;
 };
+
+export const getTokenAccountRentExemptFees = async (assetId: string) =>
+  getRentExemptFees(TOKEN_ACCOUNT_DATA_LENGTH, assetId);
+
+export const getNativeAccountRentExemptFees = async (assetId: string) =>
+  getRentExemptFees(NATIVE_ACCOUNT_DATA_LENGTH, assetId);
 
 export const broadcastTransactionToBlockchain = async (
   transaction: string,

--- a/packages/coin-support-solana/src/services/api/wallet.ts
+++ b/packages/coin-support-solana/src/services/api/wallet.ts
@@ -49,3 +49,21 @@ export const doesAccountExist = async (address: string, assetId: string) => {
   // if account doesn't exist accountInfo.value comes null
   return accountInfo.value !== undefined && accountInfo.value !== null;
 };
+
+export const getAccountDataLength = async (
+  address: string,
+  assetId: string,
+) => {
+  const accountInfo = await getAccountInfo(address, assetId);
+
+  let dataLength = 0;
+  if (Array.isArray(accountInfo.value?.data)) {
+    // for native account
+    dataLength = accountInfo.value.data[0].length ?? 0;
+  } else if (typeof accountInfo.value?.data === 'object') {
+    // for token account
+    dataLength = accountInfo.value.data.space ?? 0;
+  }
+
+  return dataLength;
+};

--- a/packages/coin-support-solana/src/services/helpers/transactions.ts
+++ b/packages/coin-support-solana/src/services/helpers/transactions.ts
@@ -80,10 +80,7 @@ export const constructTransaction = async (
   instructions: ICustomSolanaInstruction[],
   options?: IConstructTransactionOptions,
 ) => {
-  let { computeUnitPrice = 0 } = options ?? {};
-  const { computeUnits = 200_000, useMinimumAmounts = false } = options ?? {};
-
-  if (useMinimumAmounts) computeUnitPrice = 0;
+  const { computeUnits = 200_000, computeUnitPrice = 0 } = options ?? {};
 
   const recentBlockhash = await getLatestBlockHash(
     solanaCoinList[assetId].network,
@@ -115,7 +112,7 @@ export const constructTransaction = async (
       constructedInstruction = web3Lib.SystemProgram.transfer({
         fromPubkey: feePayer,
         toPubkey: new web3Lib.PublicKey(instruction.recipient),
-        lamports: useMinimumAmounts ? 1 : instruction.amount,
+        lamports: instruction.amount,
       });
     } else {
       if (!instruction.mintAddress) continue;
@@ -146,7 +143,7 @@ export const constructTransaction = async (
             mintPubKey,
             recipientTokenAccount,
             feePayer,
-            useMinimumAmounts ? 1 : instruction.amount,
+            instruction.amount,
             instruction.decimals,
           );
       }

--- a/packages/coin-support-solana/src/services/helpers/types.ts
+++ b/packages/coin-support-solana/src/services/helpers/types.ts
@@ -39,5 +39,4 @@ export type ICustomSolanaInstruction =
 export interface IConstructTransactionOptions {
   computeUnits?: number;
   computeUnitPrice?: number;
-  useMinimumAmounts?: boolean; // Used for simulating transaction without using actual amounts
 }

--- a/packages/coin-support-solana/tests/06.signTransaction.ts
+++ b/packages/coin-support-solana/tests/06.signTransaction.ts
@@ -23,7 +23,8 @@ const transaction: IPreparedSolanaTransaction = {
     isSendAll: false,
   },
   staticData: {
-    fees: '5000',
+    baseFee: '5000',
+    rentExempt: '890880',
   },
   computedData: {
     fees: '5000',
@@ -48,6 +49,7 @@ const transaction: IPreparedSolanaTransaction = {
     ownOutputAddressNotAllowed: [],
     zeroAmountNotAllowed: false,
     isRentExemptFeeRequired: false,
+    isAmountBelowRentExempt: false,
   },
 };
 

--- a/packages/coin-support-solana/tests/__fixtures__/04.initializeTransaction.ts
+++ b/packages/coin-support-solana/tests/__fixtures__/04.initializeTransaction.ts
@@ -23,20 +23,22 @@ export const valid: IInitializeTransactionTestCases[] = [
         ownOutputAddressNotAllowed: [],
         zeroAmountNotAllowed: false,
         isRentExemptFeeRequired: false,
+        isAmountBelowRentExempt: false,
       },
       userInputs: {
         outputs: [],
         isSendAll: false,
       },
       staticData: {
-        fees: '5000',
+        baseFee: '5000',
+        rentExempt: '890880',
       },
       computedData: {
         output: { address: '', amount: '0' },
-        fees: '5000',
+        fees: '6000',
         instructions: [],
-        computeUnitPriceMicroLamports: 100,
-        computeUnits: 150,
+        computeUnitPriceMicroLamports: 100_000,
+        computeUnits: 10_000,
       },
     },
     mocks: {
@@ -47,8 +49,8 @@ export const valid: IInitializeTransactionTestCases[] = [
         xpubOrAddress: 'CnHNArLuS9r9iSLq2iYdPeWdvg2B5GH8dAGJrJmVrVph',
       },
       fees: '5000',
-      computeUnitPriceMicroLamports: 100,
-      computeUnits: 150,
+      computeUnitPriceMicroLamports: 100_000,
+      computeUnits: 10_000,
     },
   },
 ];

--- a/packages/coin-support-solana/tests/__fixtures__/05.prepareTransaction.ts
+++ b/packages/coin-support-solana/tests/__fixtures__/05.prepareTransaction.ts
@@ -19,7 +19,8 @@ export const valid: IPrepareTransactionTestCases[] = [
         isSendAll: false,
       },
       staticData: {
-        fees: '5000',
+        baseFee: '5000',
+        rentExempt: '890880',
       },
       computedData: {
         output: { address: 'address', amount: '0' },
@@ -35,6 +36,7 @@ export const valid: IPrepareTransactionTestCases[] = [
         ownOutputAddressNotAllowed: [],
         zeroAmountNotAllowed: false,
         isRentExemptFeeRequired: false,
+        isAmountBelowRentExempt: false,
       },
     },
     mocks: {
@@ -51,7 +53,8 @@ export const valid: IPrepareTransactionTestCases[] = [
         isSendAll: false,
       },
       staticData: {
-        fees: '5000',
+        baseFee: '5000',
+        rentExempt: '890880',
       },
       computedData: {
         fees: '5000',
@@ -70,6 +73,7 @@ export const valid: IPrepareTransactionTestCases[] = [
         ownOutputAddressNotAllowed: [],
         zeroAmountNotAllowed: false,
         isRentExemptFeeRequired: false,
+        isAmountBelowRentExempt: false,
       },
     },
   },

--- a/packages/coin-support-solana/tests/__fixtures__/07.broadcastTransaction.ts
+++ b/packages/coin-support-solana/tests/__fixtures__/07.broadcastTransaction.ts
@@ -27,7 +27,8 @@ export const valid: IPrepareTransactionTestCases[] = [
         isSendAll: false,
       },
       staticData: {
-        fees: '5000',
+        baseFee: '5000',
+        rentExempt: '890880',
       },
       computedData: {
         output: {
@@ -52,6 +53,7 @@ export const valid: IPrepareTransactionTestCases[] = [
         ownOutputAddressNotAllowed: [],
         zeroAmountNotAllowed: false,
         isRentExemptFeeRequired: false,
+        isAmountBelowRentExempt: false,
       },
     },
     mocks: {

--- a/packages/coin-support-solana/tests/__mocks__/services.ts
+++ b/packages/coin-support-solana/tests/__mocks__/services.ts
@@ -4,7 +4,19 @@ export const getTransactions = jest
   .fn()
   .mockReturnValue(Promise.resolve({ data: [] }));
 export const getBalance = jest.fn().mockReturnValue(Promise.resolve('0'));
+export const doesAccountExist = jest
+  .fn()
+  .mockReturnValue(Promise.resolve(true));
 export const getFees = jest.fn().mockReturnValue(Promise.resolve('5000'));
+export const getRentExemptFees = jest
+  .fn()
+  .mockReturnValue(Promise.resolve('890880'));
+export const getNativeAccountRentExemptFees = jest
+  .fn()
+  .mockReturnValue(Promise.resolve('890880'));
+export const getTokenAccountRentExemptFees = jest
+  .fn()
+  .mockReturnValue(Promise.resolve('2039280'));
 export const getPriorityFees = jest.fn().mockReturnValue(Promise.resolve(100));
 export const getSimulationComputeUnits = jest
   .fn()
@@ -20,9 +32,13 @@ jest.mock('../../src/services', () => ({
   __esModule: true,
   getTransactions,
   getBalance,
+  doesAccountExist,
   getFees,
   getPriorityFees,
   getSimulationComputeUnits,
   broadcastTransactionToBlockchain,
   checkTransactionStatus,
+  getRentExemptFees,
+  getNativeAccountRentExemptFees,
+  getTokenAccountRentExemptFees,
 }));

--- a/packages/cysync-core/src/dialogs/Send/Dialogs/Recipient.tsx
+++ b/packages/cysync-core/src/dialogs/Send/Dialogs/Recipient.tsx
@@ -85,7 +85,9 @@ export const Recipient: React.FC = () => {
         !(transaction.validation as IPreparedXrpTransaction['validation'])
           .isInvalidDestinationTag &&
         !(transaction.validation as IPreparedSolanaTransaction['validation'])
-          .isBalanceBelowRentExempt,
+          .isBalanceBelowRentExempt &&
+        !(transaction.validation as IPreparedSolanaTransaction['validation'])
+          .isAmountBelowRentExempt,
     );
   }, [transaction]);
 

--- a/packages/cysync-core/src/dialogs/Send/Dialogs/Recipient.tsx
+++ b/packages/cysync-core/src/dialogs/Send/Dialogs/Recipient.tsx
@@ -85,8 +85,6 @@ export const Recipient: React.FC = () => {
         !(transaction.validation as IPreparedXrpTransaction['validation'])
           .isInvalidDestinationTag &&
         !(transaction.validation as IPreparedSolanaTransaction['validation'])
-          .isBalanceBelowRentExempt &&
-        !(transaction.validation as IPreparedSolanaTransaction['validation'])
           .isAmountBelowRentExempt,
     );
   }, [transaction]);

--- a/packages/cysync-core/src/dialogs/Send/Dialogs/Recipient.tsx
+++ b/packages/cysync-core/src/dialogs/Send/Dialogs/Recipient.tsx
@@ -1,5 +1,6 @@
 import { getDefaultUnit, getParsedAmount } from '@cypherock/coin-support-utils';
 import { IPreparedBtcTransaction } from '@cypherock/coin-support-btc';
+import { IPreparedSolanaTransaction } from '@cypherock/coin-support-solana';
 import { IPreparedXrpTransaction } from '@cypherock/coin-support-xrp';
 import {
   BlockchainIcon,
@@ -82,7 +83,9 @@ export const Recipient: React.FC = () => {
         !(transaction.validation as IPreparedXrpTransaction['validation'])
           .isFeeBelowMin &&
         !(transaction.validation as IPreparedXrpTransaction['validation'])
-          .isInvalidDestinationTag,
+          .isInvalidDestinationTag &&
+        !(transaction.validation as IPreparedSolanaTransaction['validation'])
+          .isBalanceBelowRentExempt,
     );
   }, [transaction]);
 

--- a/packages/cysync-core/src/dialogs/Send/context/index.tsx
+++ b/packages/cysync-core/src/dialogs/Send/context/index.tsx
@@ -760,6 +760,26 @@ export const SendDialogProvider: FC<SendDialogContextProviderProps> = ({
       );
     }
 
+    if (solanaValidation.isAmountBelowRentExempt && selectedAccount) {
+      const { rentExempt } = (transaction as IPreparedSolanaTransaction)
+        .staticData;
+
+      const { amount: _amount, unit } = getParsedAmount({
+        coinId: selectedAccount.parentAssetId,
+        assetId: selectedAccount.assetId,
+        unitAbbr:
+          selectedAccount.unit ??
+          getDefaultUnit(selectedAccount.parentAssetId, selectedAccount.assetId)
+            .abbr,
+        amount: rentExempt,
+      });
+
+      return parseLangTemplate(
+        lang.strings.send.recipient.amount.amountBelowReserveBalance,
+        { amount: _amount, unit: unit.abbr },
+      );
+    }
+
     return '';
   }, [transaction, lang, selectedAccount]);
 

--- a/packages/cysync-core/src/dialogs/Send/context/index.tsx
+++ b/packages/cysync-core/src/dialogs/Send/context/index.tsx
@@ -737,29 +737,6 @@ export const SendDialogProvider: FC<SendDialogContextProviderProps> = ({
     const solanaValidation =
       transaction?.validation as IPreparedSolanaTransaction['validation'];
 
-    if (solanaValidation.isBalanceBelowRentExempt && selectedAccount) {
-      const rentExempt = selectedAccount.spendableBalance
-        ? new BigNumber(selectedAccount.balance)
-            .minus(selectedAccount.spendableBalance)
-            .toString()
-        : '890880';
-
-      const { amount: _amount, unit } = getParsedAmount({
-        coinId: selectedAccount.parentAssetId,
-        assetId: selectedAccount.assetId,
-        unitAbbr:
-          selectedAccount.unit ??
-          getDefaultUnit(selectedAccount.parentAssetId, selectedAccount.assetId)
-            .abbr,
-        amount: rentExempt,
-      });
-
-      return parseLangTemplate(
-        lang.strings.send.recipient.amount.balanceBelowReserveBalance,
-        { amount: _amount, unit: unit.abbr },
-      );
-    }
-
     if (solanaValidation.isAmountBelowRentExempt && selectedAccount) {
       const { rentExempt } = (transaction as IPreparedSolanaTransaction)
         .staticData;

--- a/packages/cysync-core/src/dialogs/Send/context/index.tsx
+++ b/packages/cysync-core/src/dialogs/Send/context/index.tsx
@@ -734,6 +734,32 @@ export const SendDialogProvider: FC<SendDialogContextProviderProps> = ({
       );
     }
 
+    const solanaValidation =
+      transaction?.validation as IPreparedSolanaTransaction['validation'];
+
+    if (solanaValidation.isBalanceBelowRentExempt && selectedAccount) {
+      const rentExempt = selectedAccount.spendableBalance
+        ? new BigNumber(selectedAccount.balance)
+            .minus(selectedAccount.spendableBalance)
+            .toString()
+        : '890880';
+
+      const { amount: _amount, unit } = getParsedAmount({
+        coinId: selectedAccount.parentAssetId,
+        assetId: selectedAccount.assetId,
+        unitAbbr:
+          selectedAccount.unit ??
+          getDefaultUnit(selectedAccount.parentAssetId, selectedAccount.assetId)
+            .abbr,
+        amount: rentExempt,
+      });
+
+      return parseLangTemplate(
+        lang.strings.send.recipient.amount.balanceBelowReserveBalance,
+        { amount: _amount, unit: unit.abbr },
+      );
+    }
+
     return '';
   }, [transaction, lang, selectedAccount]);
 


### PR DESCRIPTION
- fixes simulation failing issue due to use of min amounts
- fixes txn failing issue on send max by calculating the correct amount to send
- adds spendable balance field in solana account (spendableBalance = balance - rentExempt)
- adds validation to send atleast rentExempt amount to recipient address if it doesn't exist on blockchain yet.