### PR TITLE
fix: continue btn disable on btc send max

### DIFF
--- a/packages/coin-support-btc/src/operations/prepareTransaction/index.ts
+++ b/packages/coin-support-btc/src/operations/prepareTransaction/index.ts
@@ -118,6 +118,8 @@ export const prepareTransaction = async (
         },
       ];
       isNotOverDustThreshold.push(true);
+    } else if (result.outputs !== undefined) {
+      isNotOverDustThreshold.push(false);
     }
   } else {
     isNotOverDustThreshold = validateOutputAmountsForDustThreshold(

--- a/packages/cysync-core/src/dialogs/Send/Dialogs/Recipient.tsx
+++ b/packages/cysync-core/src/dialogs/Send/Dialogs/Recipient.tsx
@@ -79,7 +79,11 @@ export const Recipient: React.FC = () => {
 
     const isBtcValid = (
       validation: IPreparedBtcTransaction['validation'],
-    ): boolean => !validation?.isNotOverDustThreshold?.every(value => value);
+    ): boolean =>
+      !(
+        validation?.isNotOverDustThreshold?.length > 0 &&
+        validation.isNotOverDustThreshold.every(value => value)
+      );
 
     const isXrpValid = (
       validation: IPreparedXrpTransaction['validation'],


### PR DESCRIPTION
On send max, dust threshold validation check was not properly verified